### PR TITLE
Make dicerolls under python3 actually work.

### DIFF
--- a/blueprint/dice.py
+++ b/blueprint/dice.py
@@ -7,9 +7,10 @@ __all__ = ['roll', 'dcompile']
 
 try:
     _ = xrange
-    del _
 except NameError:
-    xrange = range  # Python 3
+    # Python 3
+    xrange = range
+    basestring = str
 
 dice_cp = re.compile(r'(?P<num>\d+)d(?P<sides>\d+)')
 fudge_cp = re.compile(r'(?P<num>\d+)d[fF]')
@@ -73,8 +74,17 @@ class results(list):
     def __div__(self, b):
         return self._convert(b) / b
 
+    __truediv__ = __div__
+    def __floordiv__(self, b):
+        return self._convert(b) // b
+
     def __rdiv__(self, a):
         return a / self._convert(a)
+
+    __rtruediv__ = __rdiv__
+
+    def __rfloordiv__(self, a):
+        return a // self._convert(a)
 
     def __eq__(self, b):
         return b == self._convert(b)
@@ -115,5 +125,6 @@ def roll(dice_expr, random_obj=None, **kwargs):
     local_vars = dict(**kwargs)
     local_vars['random'] = random_obj
     local_vars['results'] = results
+    local_vars['xrange'] = xrange
 
     return eval(dice_expr, local_vars)

--- a/blueprint/fields.py
+++ b/blueprint/fields.py
@@ -14,6 +14,7 @@ try:
     del _
 except NameError:
     xrange = range  # Python 3
+    basestring = str
 
 __all__ = ['Field', 'RandomInt', 'Dice', 'DiceTable',
            'PickOne', 'PickFrom', 'All',
@@ -61,8 +62,20 @@ class Field(object):
     def __div__(self, b):
         return Divide(self, b)
 
+    __truediv__ = __div__
+
+    def __floordiv__(self, b):
+        return FloorDivide(self, b)
+
     def __rdiv__(self, a):
         return Divide(a, self)
+
+    __rtruediv__ = __rdiv__
+
+    def __rfloordiv__(self, a):
+        return FloorDivide(a, self)
+
+
 
 
 class _Operator(Field):
@@ -120,11 +133,15 @@ class Multiply(_Operator):
 class Divide(_Operator):
     """When resolved, divides all the provided arguments and returns the result.
     """
-    try:
-        op = operator.div
-    except AttributeError:  # Python 3 (note that this returns a float unless: operands are integral and there is no remainder.)
-        op = operator.truediv
+    op = operator.truediv
     sym = '/'
+
+
+class FloorDivide(_Operator):
+    """When resolved, divides-with-truncation all the provided arguments and returns the result.
+    """
+    op = operator.floordiv
+    sym = '//'
 
 
 class RandomInt(Field):

--- a/features/steps/dice_steps.py
+++ b/features/steps/dice_steps.py
@@ -3,6 +3,10 @@
 """
 from behave import given, when, then
 
+try:
+    _ = xrange
+except NameError:
+    xrange = range # Python 3
 
 @given(u'I have {dice_expr}')
 def dice_step(context, dice_expr):


### PR DESCRIPTION
Also improves clarity of division semantics;
a / b (where a is a results-list or a participant in an Operator) performs true division,
a // b performs truncating division (eg. 25 / 4 == 6).
