### PR TITLE
Fix rst formatting issue in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -250,8 +250,7 @@ from the project root.
 
 .. _behave: http://packages.python.org/behave/
 
-
- If you're really high class, your code will be `PEP8`_ compliant, and
+If you're really high class, your code will be `PEP8`_ compliant, and
 will pass the `pep8 static checker`_ like so::
 
     pep8 --ignore=E221,E701,E202,E203,E225,E251,E5,W291,W293 mymodule.py


### PR DESCRIPTION
Blueprint's README isn't being rendered correctly [on PyPi](https://pypi.python.org/pypi/python-blueprint/).

This fix takes care of the ReStructuredText warning that was being thrown and should fix things on PyPi next time you cut a release.

See the bottom of [this document] about rst parsing for `long_description` in `setup.py`.
